### PR TITLE
Schedule view adjusted to show the classes arranged by hour rather than by class

### DIFF
--- a/src/main/java/TODO/Main.java
+++ b/src/main/java/TODO/Main.java
@@ -184,7 +184,7 @@ public class Main {
         }
     }
 
-    public static void viewScheduleInCalendarFormat(Schedule schedule) {
+    public static void viewScheduleInCalendarFormatOLD(Schedule schedule) {
         System.out.println("Schedule: " + schedule.getName());
 
         // create map to store data for each class
@@ -195,6 +195,7 @@ public class Main {
             for (ClassTime t : c.getTimes()) {
                 String className = c.getName() + " " + c.getSection();
                 String time = c.getSubject() + " " + c.getNumber() + " " + c.getSection() + " " + t.getStartTime() + " - " + t.getEndTime();
+                String startTime = t.getStartTime();
                 String day = t.getDay();
 
                 if (!classData.containsKey(className)) {
@@ -216,7 +217,7 @@ public class Main {
         // display the schedule in a weekly calendar format
         System.out.println("Weekly Schedule:");
         System.out.println("-------------------------------------------------");
-        System.out.printf("%-40s|%-31s|%-31s|%-31s|%-31s|%-31s%n", "Class Name", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday");
+        System.out.printf("%-20s|%-35s|%-35s|%-35s|%-35s|%-35s%n", "Class Name", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday");
         System.out.println("-------------------------------------------------");
         // display classes per day
         for (String className : classData.keySet()) {
@@ -245,8 +246,70 @@ public class Main {
                         break;
                 }
             }
-            System.out.printf("%-40s|%-31s|%-31s|%-31s|%-31s|%-31s%n", className, days[0], days[1], days[2], days[3], days[4]);
+            System.out.printf("%-20s|%-35s|%-35s|%-35s|%-35s|%-35s%n", className, days[0], days[1], days[2], days[3], days[4]);
         }
+    }
+
+    public static void viewScheduleInCalendarFormat(Schedule schedule) {
+        System.out.println("Schedule: " + schedule.getName());
+        //Row across the top indicating the days of the week
+        System.out.println("Weekly Schedule:");
+        System.out.println("-------------------------------------------------");
+        System.out.printf("%-20s|%-30s|%-30s|%-30s|%-30s|%-30s%n", "Time", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday");
+        System.out.println("-------------------------------------------------");
+
+        //Variables for each line that gets printed off
+        String time;
+
+        //Loop through each half hour
+        for(int i = 16; i < 42; i++) {
+           if(i % 2 == 0) {
+               time = (i / 2) + ":00:00";
+           } else {
+               time = (i / 2) + ":30:00";
+           }
+
+           //Creating the string for each day in here so that it gets reset for each line
+            String M = "";
+            String T = "";
+            String W = "";
+            String R = "";
+            String F = "";
+
+            //Look at each class and for each class's times check to see if they start at the half hour line we're on
+            //If so, add the class's name to show up under the appropriate column.
+           for(Class c : schedule.getClasses()) {
+               for (ClassTime t : c.getTimes()) {
+                   String startTime = t.getStartTime();
+                   if(startTime.equals(time)) {
+                       String day = t.getDay();
+                       switch (day) {
+                           case "M":
+                            M = c.getSubject() + " " + c.getNumber() + " " + c.getSection();
+                            break;
+                        case "T":
+                            T = c.getSubject() + " " + c.getNumber() + " " + c.getSection();
+                            break;
+                        case "W":
+                            W = c.getSubject() + " " + c.getNumber() + " " + c.getSection();
+                            break;
+                        case "R":
+                            R = c.getSubject() + " " + c.getNumber() + " " + c.getSection();
+                            break;
+                        case "F":
+                            F = c.getSubject() + " " + c.getNumber() + " " + c.getSection();
+                            break;
+                       }
+                   }
+               }
+           }
+
+            if((i % 2) == 1) {
+                time = "";
+            }
+            System.out.printf("%-20s|%-30s|%-30s|%-30s|%-30s|%-30s%n", time, M, T, W, R, F);
+        }
+
     }
 
     private static void createSchedule(Scanner scan, Account currentAccount) {

--- a/src/main/java/TODO/Schedule.java
+++ b/src/main/java/TODO/Schedule.java
@@ -1,6 +1,6 @@
 package TODO;
 
-import java.util.ArrayList;
+import java.util.*;
 
 public class Schedule {
 
@@ -56,13 +56,6 @@ public class Schedule {
 
 
         }
-        /* I do not understand this code, so I will leave it commented out
-            Buf if it doesn't, we can use this, though at that point, we might as well eliminate the hasClass method and combine them
-            for(int i = 0; i < classes.size(); i++) {
-                if((c.getCourseCode().equals(classes.get(i).getCourseCode())) && (c.getSection() == classes.get(i).getSection())) {
-                    classes.remove(i);
-                }
-            } */
     }
 
     /*
@@ -80,12 +73,6 @@ public class Schedule {
             }
         }
         return false;
-        /* I do not understand this code so I will comment it out
-        for(int i = 0; i < classes.size(); i++) {
-                if((c.getCourseCode().equals(classes.get(i).getCourseCode())) && (c.getSection() == classes.get(i).getSection())) {
-                    return true;
-                }
-        }*/
     }
 
 
@@ -102,11 +89,5 @@ public class Schedule {
             }
         }
         return false;
-        /* I do not understand this code so I will comment it out
-        for(int i = 0; i < classes.size(); i++) {
-            if((c.getDays().equals(classes.get(i).getDays())) && (c.getTime().equals(classes.get(i).getTime()))) {
-                return true;
-            }
-        } */
     }
 }


### PR DESCRIPTION
The original schedule view is still in main with OLD added to the end of it if we need to revert for the end of sprint 1.

I have done preliminary testing:
- To make sure that if a schedule is viewed before any classes are added that it is blank
- That adding a class will make it show up on the schedule view
- That removing a class will remove it from the schedule view

I have not done anything with multiple classes on the schedule though